### PR TITLE
Add method to handle ComposeNativeTray dependencies

### DIFF
--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,5 @@
 ID=io.github.kdroidfilter.compose.linux.packagedeps
-VERSION=0.2.0
+VERSION=0.2.1
 GROUP=io.github.kdroidfilter
 DISPLAY_NAME=Compose Desktop Linux Package Deps (DEB)
 DESCRIPTION=Gradle plugin for Compose Desktop that injects Linux package dependencies into jpackage outputs (DEB/RPM): adds Depends/Requires automatically.

--- a/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/LinuxDebConfigExtension.kt
+++ b/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/LinuxDebConfigExtension.kt
@@ -37,4 +37,21 @@ abstract class LinuxDebConfigExtension @Inject constructor(project: Project) {
         // libpng16-16t64 -> "libpng16-16t64 | libpng16-16"
         enableT64AlternativeDeps.convention(false)
     }
+
+    /**
+     * Convenience method to add dependencies required by compose-desktop-tray (Qt5 + dbusmenu).
+     * Always adds the t64-first alternatives for better cross-distro compatibility.
+     *
+     * You can still fully override with: debDepends.set(listOf("..."))
+     */
+    fun addComposeNativeTrayDeps() {
+        debDepends.addAll(
+            listOf(
+                "libqt5core5t64 | libqt5core5a",
+                "libqt5gui5t64 | libqt5gui5",
+                "libqt5widgets5t64 | libqt5widgets5",
+                "libdbusmenu-qt5-2"
+            )
+        )
+    }
 }

--- a/plugin-build/plugin/src/test/java/io/github/kdroidfilter/compose/linux/packagedeps/PluginTest.kt
+++ b/plugin-build/plugin/src/test/java/io/github/kdroidfilter/compose/linux/packagedeps/PluginTest.kt
@@ -56,4 +56,39 @@ class PluginTest {
         Assert.assertTrue(debTask.enableT64AlternativeDeps.get())
         Assert.assertTrue(releaseTask.enableT64AlternativeDeps.get())
     }
+
+    @Test
+    fun `addComposeNativeTrayDeps always adds t64-first alternatives`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("io.github.kdroidfilter.compose.linux.packagedeps")
+        val ext = project.extensions.getByName("linuxDebConfig") as LinuxDebConfigExtension
+
+        // Call and verify fixed list regardless of flag
+        ext.addComposeNativeTrayDeps()
+        // Flip the flag to ensure it does not affect the result
+        ext.enableT64AlternativeDeps.set(false)
+
+        val expected = listOf(
+            "libqt5core5t64 | libqt5core5a",
+            "libqt5gui5t64 | libqt5gui5",
+            "libqt5widgets5t64 | libqt5widgets5",
+            "libdbusmenu-qt5-2"
+        )
+        Assert.assertEquals(expected, ext.debDepends.get())
+    }
+
+    @Test
+    fun `manual override of debDepends still works after addComposeNativeTrayDeps`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("io.github.kdroidfilter.compose.linux.packagedeps")
+        val ext = project.extensions.getByName("linuxDebConfig") as LinuxDebConfigExtension
+
+        ext.addComposeNativeTrayDeps()
+        // User overrides with their own set
+        val custom = listOf("another dependencies")
+        ext.debDepends.set(custom)
+
+        val debTask = project.tasks.getByName("debInjectDependsPackageDeb") as DebInjectDependsTask
+        Assert.assertEquals(custom, debTask.debDepends.get())
+    }
 }


### PR DESCRIPTION
### Overview

This pull request introduces the `addComposeNativeTrayDeps` method, which is designed to manage Qt5 and dbusmenu dependencies effectively. It also includes an update to existing tests and bumps the version to 0.2.1.

### Details

- Added `addComposeNativeTrayDeps` method for dependency management.
- Updated associated unit tests to ensure compatibility.
- Version incremented to 0.2.1.