### PR TITLE
Skip Debian dependency task for non-Linux hosts

### DIFF
--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,5 @@
 ID=io.github.kdroidfilter.compose.linux.packagedeps
-VERSION=0.2.1
+VERSION=0.2.2
 GROUP=io.github.kdroidfilter
 DISPLAY_NAME=Compose Desktop Linux Package Deps (DEB)
 DESCRIPTION=Gradle plugin for Compose Desktop that injects Linux package dependencies into jpackage outputs (DEB/RPM): adds Depends/Requires automatically.

--- a/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/DebInjectDependsTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/DebInjectDependsTask.kt
@@ -34,6 +34,14 @@ abstract class DebInjectDependsTask : DefaultTask() {
 
     @TaskAction
     fun injectDepends() {
+        // No-op on non-Linux hosts to provide a safe fallback
+        val osName = System.getProperty("os.name") ?: ""
+        val isLinux = osName.lowercase().contains("linux")
+        if (!isLinux) {
+            logger.lifecycle("Host OS is not Linux (detected: '$osName'). Skipping Debian dependency injection task.")
+            return
+        }
+
         ensureDpkgDebAvailable()
 
         val baseDeps = debDepends.getOrElse(emptyList())

--- a/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/DebInjectDependsTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/DebInjectDependsTask.kt
@@ -35,7 +35,7 @@ abstract class DebInjectDependsTask : DefaultTask() {
     @TaskAction
     fun injectDepends() {
         // No-op on non-Linux hosts to provide a safe fallback
-        val osName = System.getProperty("os.name") ?: ""
+        val osName = System.getProperty("os.name").orEmpty()
         val isLinux = osName.lowercase().contains("linux")
         if (!isLinux) {
             logger.lifecycle("Host OS is not Linux (detected: '$osName'). Skipping Debian dependency injection task.")


### PR DESCRIPTION
This pull request modifies the build process to skip the Debian dependency injection task on non-Linux hosts, ensuring compatibility across different environments. Additionally, the package version has been updated to 0.2.2.