### PR TITLE
fix: skip Debian injection on non-Linux and missing .deb dir

### DIFF
--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,5 @@
 ID=io.github.kdroidfilter.compose.linux.packagedeps
-VERSION=0.2.2
+VERSION=0.2.3
 GROUP=io.github.kdroidfilter
 DISPLAY_NAME=Compose Desktop Linux Package Deps (DEB)
 DESCRIPTION=Gradle plugin for Compose Desktop that injects Linux package dependencies into jpackage outputs (DEB/RPM): adds Depends/Requires automatically.

--- a/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/LinuxDebConfigPlugin.kt
+++ b/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/LinuxDebConfigPlugin.kt
@@ -10,6 +10,7 @@ const val TASK_NAME_RELEASE = "debInjectDependsPackageReleaseDeb"
 @Suppress("UnnecessaryAbstractClass")
 abstract class LinuxDebConfigPlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        val isLinux = System.getProperty("os.name").orEmpty().lowercase().contains("linux")
         // Create plugin extension with configurable properties
         val extension = project.extensions.create(EXTENSION_NAME, LinuxDebConfigExtension::class.java, project)
 
@@ -22,6 +23,8 @@ abstract class LinuxDebConfigPlugin : Plugin<Project> {
             task.enableT64AlternativeDeps.set(extension.enableT64AlternativeDeps)
             // main variant keeps using the extension-configured directory (defaults to main)
             task.debDirectory.set(extension.debDirectory)
+            // Gate execution on Linux hosts only
+            task.onlyIf { isLinux }
         }
         val releaseDir = project.layout.buildDirectory.dir("compose/binaries/main-release/deb")
         val injectReleaseTask = project.tasks.register(TASK_NAME_RELEASE, DebInjectDependsTask::class.java) { task ->
@@ -32,6 +35,8 @@ abstract class LinuxDebConfigPlugin : Plugin<Project> {
             task.enableT64AlternativeDeps.set(extension.enableT64AlternativeDeps)
             // release variant must use main-release directory
             task.debDirectory.set(releaseDir)
+            // Gate execution on Linux hosts only
+            task.onlyIf { isLinux }
         }
 
         // Hook automatically: run after the corresponding packaging tasks (avoid dependsOn to prevent loops)


### PR DESCRIPTION
This PR fixes a configuration error when applying the plugin on macOS/Windows or before packaging.\n\nChanges\n- Mark  as  to avoid Gradle input validation when the directory doesn’t exist yet.\n- Add  to both injection tasks to skip execution on non-Linux hosts.\n- Gracefully skip with a lifecycle log when the  directory isn’t present.\n- Bump plugin version to .\n\nWhy\n- Prevents failures like: \n  > property 'debDirectory' specifies directory '.../compose/binaries/main-release/deb' which doesn't exist.\n\nValidation\n- Starting a Gradle Daemon, 2 incompatible Daemons could not be reused, use --status for details
> Task :plugin:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :plugin:compileKotlin UP-TO-DATE
> Task :plugin:compileJava NO-SOURCE
> Task :plugin:pluginDescriptors UP-TO-DATE
> Task :plugin:processResources UP-TO-DATE
> Task :plugin:classes UP-TO-DATE
> Task :plugin:jar UP-TO-DATE
> Task :plugin:compileTestKotlin UP-TO-DATE
> Task :plugin:compileTestJava NO-SOURCE
> Task :plugin:pluginUnderTestMetadata UP-TO-DATE
> Task :plugin:processTestResources NO-SOURCE
> Task :plugin:testClasses UP-TO-DATE
> Task :plugin:test

BUILD SUCCESSFUL in 4s
7 actionable tasks: 1 executed, 6 up-to-date and  are green.\n\nNo functional changes on Linux when the .deb exists; the tasks still run post /.