### PR TITLE
plugin: config-cache friendly DebInjectDependsTask; bump to 0.2.4

### DIFF
--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,5 @@
 ID=io.github.kdroidfilter.compose.linux.packagedeps
-VERSION=0.2.3
+VERSION=0.2.4
 GROUP=io.github.kdroidfilter
 DISPLAY_NAME=Compose Desktop Linux Package Deps (DEB)
 DESCRIPTION=Gradle plugin for Compose Desktop that injects Linux package dependencies into jpackage outputs (DEB/RPM): adds Depends/Requires automatically.

--- a/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/DebInjectDependsTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/kdroidfilter/compose/linux/packagedeps/DebInjectDependsTask.kt
@@ -2,6 +2,7 @@ package io.github.kdroidfilter.compose.linux.packagedeps
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -14,6 +15,8 @@ import javax.inject.Inject
 abstract class DebInjectDependsTask : DefaultTask() {
     @get:Inject
     protected abstract val execOperations: ExecOperations
+    @get:Inject
+    protected abstract val layout: ProjectLayout
 
     init {
         description = "Inject Debian Depends into jpackage-generated .deb files"
@@ -83,7 +86,7 @@ abstract class DebInjectDependsTask : DefaultTask() {
     }
 
     private fun extractDebToWorkDir(debFile: File): File {
-        val workDir = project.layout.buildDirectory.dir("deb-edit").get().asFile
+        val workDir = layout.buildDirectory.dir("deb-edit").get().asFile
         workDir.deleteRecursively()
         workDir.mkdirs()
         execOperations.exec { execSpec ->


### PR DESCRIPTION
Fix configuration cache violation: task used Task.project at execution time.\n\nChanges\n- Inject Gradle ProjectLayout into DebInjectDependsTask via @Inject.\n- Replace project.layout usage with layout.buildDirectory.\n- Bump plugin VERSION to 0.2.4.\n\nWhy\n- Configuration cache forbids accessing Task.project during execution.\n- Ensures :debInjectDepends* tasks are cache-compatible.\n\nValidation\n- :plugin:test and root preMerge pass locally.\n- No functional change to packaging; behavior only more cache-friendly.\n\nNotes\n- No public API changes; extension remains the same.\n- Safe on non-Linux (task is no-op).